### PR TITLE
Setting up auto reload for celery to ease development

### DIFF
--- a/compose/local/fastapi/celery/worker/start
+++ b/compose/local/fastapi/celery/worker/start
@@ -3,4 +3,5 @@
 set -o errexit
 set -o nounset
 
-celery -A main.celery worker --loglevel=info
+# celery -A main.celery worker --loglevel=info
+python main.py

--- a/main.py
+++ b/main.py
@@ -3,3 +3,17 @@ from project import create_app
 
 app = create_app()
 celery = app.celery_app
+
+
+def celery_worker():
+    from watchgod import run_process
+    import subprocess
+
+    def run_worker():
+        subprocess.call(["celery", "-A", "main.celery", "worker", "--loglevel=info"])
+
+    run_process("./project", run_worker)
+
+
+if __name__ == "__main__":
+    celery_worker()

--- a/poetry.lock
+++ b/poetry.lock
@@ -534,6 +534,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "watchgod"
+version = "0.7"
+description = "Simple, modern file watching and code reload in python."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -544,7 +552,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "41b8f267fea1196cdb64953e90f45f9b691133b4ff954c8c8950b0081b3431c4"
+content-hash = "aa94faee6592cccf97028a47a8a1c946f40f8b445aa7e4550683bb9ada3f1c37"
 
 [metadata.files]
 alembic = [
@@ -955,6 +963,10 @@ uvicorn = [
 vine = [
     {file = "vine-5.0.0-py2.py3-none-any.whl", hash = "sha256:4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30"},
     {file = "vine-5.0.0.tar.gz", hash = "sha256:7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e"},
+]
+watchgod = [
+    {file = "watchgod-0.7-py3-none-any.whl", hash = "sha256:d6c1ea21df37847ac0537ca0d6c2f4cdf513562e95f77bb93abbcf05573407b7"},
+    {file = "watchgod-0.7.tar.gz", hash = "sha256:48140d62b0ebe9dd9cf8381337f06351e1f2e70b2203fa9c6eff4e572ca84f29"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/project/users/tasks.py
+++ b/project/users/tasks.py
@@ -5,5 +5,5 @@ from celery import shared_task
 def divide(x, y):
     import time
 
-    time.sleep(5)
+    time.sleep(4)
     return x / y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ flower = "1.0.0"
 alembic = "1.6.5"
 SQLAlchemy = "1.4.20"
 psycopg2-binary = "2.9.1"
+watchgod = "0.7"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^21.10b0", allow-prereleases = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ flower==1.0.0
 alembic==1.6.5
 SQLAlchemy==1.4.20
 psycopg2-binary==2.9.1
+watchgod==0.7


### PR DESCRIPTION
Live code reloading is not enabled in Celery but it is for the uvicorn. To enable the hot reload for celery it needs `watchgod` dependencies and call it when change happened like what happened to uvicorn hot reloading.

- [x] Edited `main.py` to have a subprocess call for hot reloading celery
- [x] Edited the start script for celery worker.