### PR TITLE
Add debugger for celery

### DIFF
--- a/project/users/tasks.py
+++ b/project/users/tasks.py
@@ -3,6 +3,10 @@ from celery import shared_task
 
 @shared_task
 def divide(x, y):
+    # from celery.contrib import rdb
+
+    # rdb.set_trace()
+
     import time
 
     time.sleep(4)


### PR DESCRIPTION
In celery debugging is taking several ways, in here to ensure developer can debug it without changing workflow here I comment a debugger for celery using rdb. Since telnet and netcat already configured prior previous PR in dockerfile.

To activate the debugger it only needs to uncomment tasks.py `rdb.set_trace()`, run the docker image, exec shell, exec celery worker bash, then run `telnet 127.0.0.1 6903` and start debugging