### PR TITLE
Websockets and Celery

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -52,6 +52,17 @@ python-versions = ">=3.6"
 tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
+name = "asyncio-redis"
+version = "0.16.0"
+description = "PEP 3156 implementation of the redis protocol."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+hiredis = ["hiredis"]
+
+[[package]]
 name = "billiard"
 version = "3.6.4.0"
 description = "Python multiprocessing fork with improvements and bugfixes"
@@ -85,6 +96,19 @@ d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 python2 = ["typed-ast (>=1.4.3)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "broadcaster"
+version = "0.2.0"
+description = "Simple broadcast channels."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+kafka = ["aiokafka"]
+postgres = ["asyncpg"]
+redis = ["asyncio-redis"]
 
 [[package]]
 name = "celery"
@@ -613,7 +637,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f8c3005d06c9edece4756b094d236ee32db4f1ac100d00914ac2d9a2ef346233"
+content-hash = "d7a3147a33ebe294ac2045ad3b70ba46ae179479fc069fd781516b6997ee35fe"
 
 [metadata.files]
 alembic = [
@@ -632,6 +656,10 @@ asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
     {file = "asgiref-3.4.1.tar.gz", hash = "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9"},
 ]
+asyncio-redis = [
+    {file = "asyncio_redis-0.16.0-py2.py3-none-any.whl", hash = "sha256:4a134fde5ea3628ff0c7118e2424b0f26140a1bd21d5e4632058f1f662773686"},
+    {file = "asyncio_redis-0.16.0.tar.gz", hash = "sha256:ff8ce4e7e22a08e2688ae6b397aeac355473e343ce3c68ae3b713494318d848b"},
+]
 billiard = [
     {file = "billiard-3.6.4.0-py3-none-any.whl", hash = "sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b"},
     {file = "billiard-3.6.4.0.tar.gz", hash = "sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547"},
@@ -639,6 +667,10 @@ billiard = [
 black = [
     {file = "black-21.10b0-py3-none-any.whl", hash = "sha256:6eb7448da9143ee65b856a5f3676b7dda98ad9abe0f87fce8c59291f15e82a5b"},
     {file = "black-21.10b0.tar.gz", hash = "sha256:a9952229092e325fe5f3dae56d81f639b23f7131eb840781947e4b2886030f33"},
+]
+broadcaster = [
+    {file = "broadcaster-0.2.0-py3-none-any.whl", hash = "sha256:50f93d1af7e9097a87ef3b2da269b4b4c5630ec080dc5c7f941ef314291937b1"},
+    {file = "broadcaster-0.2.0.tar.gz", hash = "sha256:72056f9b77b091dd4bbad4d7484bd0e6835c3443d4564d0bbf41190c29c606c6"},
 ]
 celery = [
     {file = "celery-5.1.2-py3-none-any.whl", hash = "sha256:9dab2170b4038f7bf10ef2861dbf486ddf1d20592290a1040f7b7a1259705d42"},

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -1,16 +1,33 @@
+from broadcaster import Broadcast
 from fastapi import FastAPI
+from project.config import settings
 
-from project.celery_utils import create_celery
+
+broadcast = Broadcast(settings.WS_MESSAGE_QUEUE)
 
 
 def create_app() -> FastAPI:
     app = FastAPI()
+
+    from project.celery_utils import create_celery
 
     app.celery_app = create_celery()
 
     from project.users import users_router
 
     app.include_router(users_router)
+
+    from project.ws import ws_router
+
+    app.include_router(ws_router)
+
+    @app.on_event("startup")
+    async def startup_event():
+        await broadcast.connect()
+
+    @app.on_event("shutdown")
+    async def shutdown_event():
+        await broadcast.disconnect()
 
     @app.get("/")
     async def root():

--- a/project/celery_utils.py
+++ b/project/celery_utils.py
@@ -1,4 +1,5 @@
 from celery import current_app as current_celery_app
+from celery.result import AsyncResult
 
 from project.config import settings
 
@@ -8,3 +9,18 @@ def create_celery():
     celery_app.config_from_object(settings, namespace="CELERY")
 
     return celery_app
+
+
+def get_task_info(task_id):
+    task = AsyncResult(task_id)
+    if task.state == "FAILURE":
+        error = str(task.result)
+        response = {
+            "state": task.state,
+            "error": error,
+        }
+    else:
+        response = {
+            "state": task.state,
+        }
+    return response

--- a/project/config.py
+++ b/project/config.py
@@ -17,6 +17,9 @@ class BaseConfig:
     CELERY_RESULT_BACKEND: str = os.environ.get(
         "CELERY_RESULT_BACKEND", "redis://127.0.0.1:6379/0"
     )
+    WS_MESSAGE_QUEUE: str = os.environ.get(
+        "WS_MESSAGE_QUEUE", "redis://127.0.0.1:6379/0"
+    )
 
 
 class DevelopmentConfig(BaseConfig):

--- a/project/users/tasks.py
+++ b/project/users/tasks.py
@@ -1,7 +1,10 @@
 import random
-from celery import shared_task
 import requests
 
+from asgiref.sync import async_to_sync
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from celery.signals import task_postrun
 from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
@@ -38,3 +41,10 @@ def task_process_notification(self):
     except Exception as e:
         logger.error("exception raised, it would be retry after 5 seconds")
         raise self.retry(exc=e, countdown=5)
+
+
+@task_postrun.connect
+def task_postrun_handler(task_id, **kwargs):
+    from project.ws.views import update_celery_task_status
+
+    async_to_sync(update_celery_task_status)(task_id)

--- a/project/users/templates/form_ws.html
+++ b/project/users/templates/form_ws.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Celery example</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.0.1/css/bootstrap.min.css"
+        integrity="sha512-Ez0cGzNzHR1tYAv56860NLspgUGuQw16GiOOp/I2LuTmpSK9xDXlgJz3XN4cnpXWDmkNBKXR/VDMTCnAaEooxA=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+
+<body>
+    <div class="container">
+        <div class="row">
+            <div class="col-12 col-md-4">
+                <form id="your-form">
+                    <div class="mb-3">
+                        <label for="email" class="form-label">Email address</label>
+                        <input type="email" class="form-control" id="email" name="email">
+                    </div>
+                    <div class="mb-3">
+                        <label for="username" class="form-label">Username</label>
+                        <input type="text" class="form-control" id="username" name="username">
+                    </div>
+                    <div class="mb-3" id="messages"></div>
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.0.1/js/bootstrap.min.js"
+        integrity="sha512-EKWWs1ZcA2ZY9lbLISPz8aGR2+L7JVYqBAYTq5AXgBkSjRSuQEGqWx8R1zAX16KdXPaCjOCaKE8MCpU0wcHlHA=="
+        crossorigin="anonymous" referrerpolicy="no-referrer">
+        </script>
+
+    <script>
+        function update_progress(yourForm, task_id, btnHtml) {
+            const ws_url = `/ws/task_status/${task_id}`;
+            const WS = new WebSocket((location.protocol === 'https:' ? 'wss' : 'ws') + '://' + window.location.host + ws_url);
+
+            WS.onmessage = function (event) {
+                const res = JSON.parse(event.data);
+                const taskStatus = res.state;
+
+                if (taskStatus !== 'PENDING' && taskStatus !== 'PROGRESS') {
+                    const msg = yourForm.querySelector('#messages');
+                    const submitBtn = yourForm.querySelector('button[type="submit"]');
+
+                    if (taskStatus === 'SUCCESS') {
+                        msg.innerHTML = 'job succeeded';
+                    } else if (taskStatus === 'FAILURE') {
+                        msg.innerHTML = res.error;
+                    }
+
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = btnHtml;
+
+                    // close the websocket because we do not need it now
+                    WS.close();
+                }
+            }
+        }
+
+        function serialize(data) {
+            let obj = {};
+            for (let [key, value] of data) {
+                if (obj[key] !== undefined) {
+                    if (!Array.isArray(obj[key])) {
+                        obj[key] = [obj[key]];
+                    }
+                    obj[key].push(value);
+                } else {
+                    obj[key] = value;
+                }
+            }
+            return obj;
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+            const yourForm = document.getElementById("your-form");
+            yourForm.addEventListener("submit", function (event) {
+                event.preventDefault();
+                const submitBtn = yourForm.querySelector('button[type="submit"]');
+                const btnHtml = submitBtn.innerHTML;
+                const spinnerHtml = 'Processing...';
+                submitBtn.disabled = true;
+                submitBtn.innerHTML = spinnerHtml;
+
+                const msg = yourForm.querySelector('#messages');
+                msg.innerHTML = '';
+
+                // Get all field data from the form
+                let data = new FormData(yourForm);
+                // Convert to an object
+                let formData = serialize(data);
+
+                fetch('/users/form/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(formData),
+                })
+                    .then(response => response.json())
+                    .then((res) => {
+                        // after we get Celery task id, we start polling
+                        const task_id = res.task_id;
+                        update_progress(yourForm, task_id, btnHtml);
+                        console.log(res);
+                    }).catch((error) => {
+                        console.error('Error:', error);
+                    });
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/project/users/views.py
+++ b/project/users/views.py
@@ -68,3 +68,8 @@ def webhook_test_2(request: Request):
     task = task_process_notification.delay()
     print(task.id)
     return "pong"
+
+
+@users_router.get("/form_ws/")
+def form_ws_example(request: Request):
+    return templates.TemplateResponse("form_ws.html", {"request": request})

--- a/project/ws/__init__.py
+++ b/project/ws/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+
+ws_router = APIRouter()
+
+from . import views

--- a/project/ws/views.py
+++ b/project/ws/views.py
@@ -1,0 +1,31 @@
+import json
+
+from fastapi import WebSocket
+
+from . import ws_router
+from project import broadcast
+from project.celery_utils import get_task_info
+
+
+@ws_router.websocket("/ws/task_status/{task_id}")
+async def ws_task_status(websocket: WebSocket):
+    await websocket.accept()
+
+    task_id = websocket.scope["path_params"]["task_id"]
+
+    async with broadcast.subscribe(channel=task_id) as subscriber:
+        #  Just in case task already finished
+        data = get_task_info(task_id)
+        await websocket.send_json(data)
+
+        async for event in subscriber:
+            await websocket.send_json(json.loads(event.message))
+
+
+async def update_celery_task_status(task_id: str):
+    """
+    This function is called by celery worker in task_postrun signal handler
+    """
+    await broadcast.connect()
+    await broadcast.publish(channel=task_id, message=json.dumps(get_task_info(task_id)))
+    await broadcast.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ psycopg2-binary = "2.9.1"
 watchgod = "0.7"
 Jinja2 = "3.0.1"
 requests = "2.25.1"
+asgiref = "3.4.1"
+asyncio-redis = "0.16.0"
+broadcaster = "0.2.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^21.10b0", allow-prereleases = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ psycopg2-binary==2.9.1
 watchgod==0.7
 Jinja2==3.0.1
 requests==2.25.1
+asgiref==3.4.1
+asyncio-redis==0.16.0
+broadcaster==0.2.0


### PR DESCRIPTION
Prior to PR #7 after integrated third-party services it was using `XHR short polling` to check the task status. Short polling could be a waste of time since it creates a lot of connections and queries and also depending on polling interval, there could be a delay between the task completing and the client updating.

- [x] Use broadcaster to handle multi-process notification via redis-pub/sub
- [x] Asyncio
- [x] Convert async to sync with asgiref

### Workflow
1. The client sends an AJAX request to a FastAPI view to trigger a Celery task.
2. FastAPI returns a task_id which can be used to receive messages about the task.
3. The client then uses the task_id to create a WebSocket connection via ws://127.0.0.1:8010/ws/task_status/{task_id}.
4. When the FastAPI view receives the WebSocket request, it subscribes to task_id channel.
5. After the Celery task finishes processing, Celery sends a message to the channel, and all clients subscribed to the channel will receive the message as well.
6. The client closes the WebSocket and displays the result on the page.
