### PR TITLE
Celery beat

### DIFF
--- a/project/config.py
+++ b/project/config.py
@@ -20,6 +20,12 @@ class BaseConfig:
     WS_MESSAGE_QUEUE: str = os.environ.get(
         "WS_MESSAGE_QUEUE", "redis://127.0.0.1:6379/0"
     )
+    CELERY_BEAT_SCHEDULE: dict = {
+        "task-schedule-work": {
+            "task": "task_schedule_work",
+            "schedule": 5.0,  # five seconds
+        }
+    }
 
 
 class DevelopmentConfig(BaseConfig):

--- a/project/users/tasks.py
+++ b/project/users/tasks.py
@@ -52,3 +52,8 @@ def task_postrun_handler(task_id, **kwargs):
     from project.ws.views import update_celery_task_status_socketio
 
     update_celery_task_status_socketio(task_id)
+
+
+@shared_task(name="task_schedule_work")
+def task_schedule_work():
+    logger.info("task_schedule_work run")


### PR DESCRIPTION
Schedule a celery task to run periodically with Celery Beat

Celery Beat is a scheduling tool used to enqueue tasks at regular intervals, which are then executed by Celery workers.

Responsibilities:

- Celery Workers are responsible for picking up tasks from the queue, running them, and returning the results.
- Celery Beat is responsible for sending tasks to the queue based on the defined config.

Reproduced in `docker-compose logs -f`

```bash
celery_beat_1    | [2021-11-08 08:12:21,905: INFO/MainProcess] Scheduler: Sending due task task-schedule-work (task_schedule_work)
celery_worker_1  | [2021-11-08 08:12:21,907: INFO/MainProcess] Task task_schedule_work[751f6676-d945-41eb-bc6f-96e747c780a3] received
celery_worker_1  | [2021-11-08 08:12:21,909: INFO/ForkPoolWorker-8] task_schedule_work[751f6676-d945-41eb-bc6f-96e747c780a3]: task_schedule_work run
celery_worker_1  | [2021-11-08 08:12:21,910: INFO/ForkPoolWorker-8] Task task_schedule_work[751f6676-d945-41eb-bc6f-96e747c780a3] succeeded in 0.001208800000000565s: None
```