### PR TITLE
Multiple Queues and Task Routing

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,17 @@ def celery_worker():
     import subprocess
 
     def run_worker():
-        subprocess.call(["celery", "-A", "main.celery", "worker", "--loglevel=info"])
+        subprocess.call(
+            [
+                "celery",
+                "-A",
+                "main.celery",
+                "worker",
+                "--loglevel=info",
+                "-Q",
+                "high_priority,default",
+            ]
+        )
 
     run_process("./project", run_worker)
 

--- a/project/config.py
+++ b/project/config.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 from functools import lru_cache
+from kombu import Queue
 
 
 class BaseConfig:
@@ -21,9 +22,23 @@ class BaseConfig:
         "WS_MESSAGE_QUEUE", "redis://127.0.0.1:6379/0"
     )
     CELERY_BEAT_SCHEDULE: dict = {
-        "task-schedule-work": {
-            "task": "task_schedule_work",
-            "schedule": 5.0,  # five seconds
+        # "task-schedule-work": {
+        #     "task": "task_schedule_work",
+        #     "schedule": 5.0,  # five seconds
+        # }
+    }
+    CELERY_TASK_DEFAULT_QUEUE: str = "default"
+    # Force all queues to be explicitly listed in CELERY_TASK_QUEUES to help prevent typos
+    CELERY_TASK_CREATE_MISSING_QUEUES: bool = False
+    CELERY_TASK_QUEUES: list = {
+        # need to define default queue here or exception would be raised
+        Queue("default"),
+        Queue("high_priority"),
+        Queue("low_priority"),
+    }
+    CELERY_TASK_ROUTES = {
+        "project.users.tasks.*": {
+            "queue": "high_priority",
         }
     }
 

--- a/project/config.py
+++ b/project/config.py
@@ -1,7 +1,13 @@
 import os
 import pathlib
-from functools import lru_cache
 from kombu import Queue
+
+
+def route_task(name, args, kwargs, options, task=None, **kw):
+    if ":" in name:
+        queue, _ = name.split(":")
+        return {"queue": queue}
+    return {"queue": "default"}
 
 
 class BaseConfig:
@@ -36,11 +42,7 @@ class BaseConfig:
         Queue("high_priority"),
         Queue("low_priority"),
     }
-    CELERY_TASK_ROUTES = {
-        "project.users.tasks.*": {
-            "queue": "high_priority",
-        }
-    }
+    CELERY_TASK_ROUTES = (route_task,)
 
 
 class DevelopmentConfig(BaseConfig):
@@ -55,7 +57,6 @@ class TestingConfig(BaseConfig):
     pass
 
 
-@lru_cache()
 def get_settings():
     config_cls_dict = {
         "development": DevelopmentConfig,

--- a/project/users/tasks.py
+++ b/project/users/tasks.py
@@ -57,3 +57,18 @@ def task_postrun_handler(task_id, **kwargs):
 @shared_task(name="task_schedule_work")
 def task_schedule_work():
     logger.info("task_schedule_work run")
+
+
+@shared_task(name="default:dynamic_example_one")
+def dynamic_example_one():
+    logger.info("Example one")
+
+
+@shared_task(name="low_priority:dynamic_example_two")
+def dynamic_example_two():
+    logger.info("Example two")
+
+
+@shared_task(name="high_priority:dynamic_example_three")
+def dynamic_example_three():
+    logger.info("Example three")


### PR DESCRIPTION
By default, Celery creates a default queue in your message broker when it's first executed. Celery then routes all tasks to that default queue and all Celery workers consume tasks from that queue as well. Celery allows you to spin up additional queues so you can have more control over which workers process which tasks.

For example, you could configure two queues: `high_priority` and `low_priority`. As the names suggest, "higher" priority tasks could be routed to the `high_priority` queue while the `low_priority` queue handles "lower" priority tasks. You can then spin up two workers: one for the `high_priority` queue and one for the `low_priority` and default queues.

- [x] Add Configuration
- [x] Celery Worker Queue
- [x] Task routing - manual routing
- [x] Task routing - dynamic routing