### PR TITLE
Using task retry decorator instead of try exception for `task_process_notification` function

### DIFF
--- a/project/users/tasks.py
+++ b/project/users/tasks.py
@@ -29,18 +29,19 @@ def sample_task(email):
     api_call(email)
 
 
-@shared_task(bind=True)
+# using task retry decorator from celery built-in
+@shared_task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_kwargs={"max_retries": 7, "countdown": 5},
+)
 def task_process_notification(self):
-    try:
-        if not random.choice([0, 1]):
-            # mimic random error
-            raise Exception()
+    if not random.choice([0, 1]):
+        # mimic random error
+        raise Exception()
 
-        #  block the I/O
-        requests.post("https://httpbin.org/delay/5")
-    except Exception as e:
-        logger.error("exception raised, it would be retry after 5 seconds")
-        raise self.retry(exc=e, countdown=5)
+    #  block the I/O
+    requests.post("https://httpbin.org/delay/5")
 
 
 @task_postrun.connect


### PR DESCRIPTION
Utilizing celery built-in function